### PR TITLE
Removed Countdown

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,19 +53,6 @@
       </div><!--/container-->
     </div><!--/H-->
 
-    <div id="g">
-      <div class="container">
-        <div class="row">
-          <div class="col-md-8 col-md-offset-2 centered">
-            <h2>We are crafting the last details to launch our site.</h2>
-            <div class="countdown-header">
-              <div class="countdown" data-date="2016/06/23"></div>
-            </div>
-          </div><!--/col-md-8-->
-        </div><!--/row-->
-      </div><!--/container-->
-    </div><!--/G-->
-
     <div class="container ptb">
       <div class="row centered">
         <div class="col-md-4">
@@ -104,6 +91,5 @@
     <script src="assets/js/jquery.plugin.min.js"></script>
     <script src="assets/js/jquery.countdown.min.js"></script>
     <script src="assets/js/retina-1.1.0.js"></script>
-    <script src="assets/js/theme.js"> </script>
   </body>
 </html>


### PR DESCRIPTION
I am not sure how useful the countdown is. Also, I looked at submitting to www.betalist.com and it seems that you are required to wait in a one-month queue if you want to take advantage of the free plan. The alternative is to pay $129 and you can get it featured next Wednesday. That's why I thought maybe we should remove the countdown to buy us more time.

There are two concerns though:

1. The page looks kind of empty and too simple without the countdown.
2. This will give us an excuse to delay launching the real page.

Thoughts?